### PR TITLE
Optimize compatibility other devices (like cpu)

### DIFF
--- a/poser/morph_rotate_combine_poser.py
+++ b/poser/morph_rotate_combine_poser.py
@@ -29,6 +29,7 @@ class MorphRotateCombinePoser(Poser):
         self.combine_module_spec = combine_module_spec
         self.combine_module_file_name = combine_module_file_name
         self.device = device
+        self.map_location = {"cuda:0": "cpu"} if self.device.type == "cpu" else None
         self._image_size = image_size
 
         self.morph_module = None
@@ -44,7 +45,7 @@ class MorphRotateCombinePoser(Poser):
     def get_morph_module(self):
         if self.morph_module is None:
             G = self.morph_module_spec.get_module().to(self.device)
-            G.load_state_dict(torch_load(self.morph_module_file_name))
+            G.load_state_dict(torch_load(self.morph_module_file_name, map_location=self.map_location))
             self.morph_module = G
             G.train(False)
         return self.morph_module
@@ -52,7 +53,7 @@ class MorphRotateCombinePoser(Poser):
     def get_rotate_module(self):
         if self.pose_module is None:
             G = self.rotate_module_spec.get_module().to(self.device)
-            G.load_state_dict(torch_load(self.rotate_module_file_name))
+            G.load_state_dict(torch_load(self.rotate_module_file_name, map_location=self.map_location))
             self.pose_module = G
             G.train(False)
         return self.pose_module
@@ -60,7 +61,7 @@ class MorphRotateCombinePoser(Poser):
     def get_combine_module(self):
         if self.combine_module is None:
             G = self.combine_module_spec.get_module().to(self.device)
-            G.load_state_dict(torch_load(self.combine_module_file_name))
+            G.load_state_dict(torch_load(self.combine_module_file_name, map_location=self.map_location))
             self.combine_module = G
             G.train(False)
         return self.combine_module

--- a/poser/morph_rotate_combine_poser.py
+++ b/poser/morph_rotate_combine_poser.py
@@ -29,7 +29,6 @@ class MorphRotateCombinePoser(Poser):
         self.combine_module_spec = combine_module_spec
         self.combine_module_file_name = combine_module_file_name
         self.device = device
-        self.map_location = {"cuda:0": "cpu"} if self.device.type == "cpu" else None
         self._image_size = image_size
 
         self.morph_module = None
@@ -45,7 +44,7 @@ class MorphRotateCombinePoser(Poser):
     def get_morph_module(self):
         if self.morph_module is None:
             G = self.morph_module_spec.get_module().to(self.device)
-            G.load_state_dict(torch_load(self.morph_module_file_name, map_location=self.map_location))
+            G.load_state_dict(torch_load(self.morph_module_file_name, map_location=self.device))
             self.morph_module = G
             G.train(False)
         return self.morph_module
@@ -53,7 +52,7 @@ class MorphRotateCombinePoser(Poser):
     def get_rotate_module(self):
         if self.pose_module is None:
             G = self.rotate_module_spec.get_module().to(self.device)
-            G.load_state_dict(torch_load(self.rotate_module_file_name, map_location=self.map_location))
+            G.load_state_dict(torch_load(self.rotate_module_file_name, map_location=self.device))
             self.pose_module = G
             G.train(False)
         return self.pose_module
@@ -61,7 +60,7 @@ class MorphRotateCombinePoser(Poser):
     def get_combine_module(self):
         if self.combine_module is None:
             G = self.combine_module_spec.get_module().to(self.device)
-            G.load_state_dict(torch_load(self.combine_module_file_name, map_location=self.map_location))
+            G.load_state_dict(torch_load(self.combine_module_file_name, map_location=self.device))
             self.combine_module = G
             G.train(False)
         return self.combine_module

--- a/util.py
+++ b/util.py
@@ -16,9 +16,9 @@ def torch_save(content, file_name):
         torch.save(content, f)
 
 
-def torch_load(file_name):
+def torch_load(file_name, **kwargs):
     with open(file_name, 'rb') as f:
-        return torch.load(f)
+        return torch.load(f, **kwargs)
 
 
 def srgb_to_linear(x):


### PR DESCRIPTION
Pass other device in `__main__` block
```python
device = torch.device("cpu")
poser = MorphRotateCombinePoser256Param6(
    ...
    device=device)
```